### PR TITLE
Add support for Oracle Linux

### DIFF
--- a/rpm/update-nodejs-and-nodered
+++ b/rpm/update-nodejs-and-nodered
@@ -56,7 +56,7 @@ case $yn in
         NODERED_GROUP=`id -gn`
 
         MYOS=$(cat /etc/*release | grep "^ID=" | cut -d = -f 2)
-        versions='fedora"centos"rhel"'
+        versions='fedora"centos"rhel"ol"'
         if [[ $versions != *"$MYOS"* ]]; then
             echo " "
             echo "Doesn't seem to be running on RedHat, Centos or Fedora, quitting"

--- a/rpm/update-nodejs-and-nodered
+++ b/rpm/update-nodejs-and-nodered
@@ -59,7 +59,7 @@ case $yn in
         versions='fedora"centos"rhel"ol"'
         if [[ $versions != *"$MYOS"* ]]; then
             echo " "
-            echo "Doesn't seem to be running on RedHat, Centos or Fedora, quitting"
+            echo "Doesn't seem to be running on Oracle Linux, RedHat, Centos or Fedora, quitting"
             echo " "
             exit 1
         fi


### PR DESCRIPTION
Installer works as expected on Oracle Linux, this script should not fail if it is detected.