### PR TITLE
add Rocky Linux as Distro

### DIFF
--- a/rpm/update-nodejs-and-nodered
+++ b/rpm/update-nodejs-and-nodered
@@ -64,10 +64,10 @@ case $yn in
         }
 
         MYOS=$(cat /etc/*release | grep "^ID=" | cut -d = -f 2)
-        versions='fedora"centos"rhel"ol"'
+        versions='fedora"rocky"centos"rhel"ol"'
         if [[ $versions != *"$MYOS"* ]]; then
             echo " "
-            echo "Doesn't seem to be running on RedHat, Centos, Fedora, or Oracle Linux, so quitting"
+            echo "Doesn't seem to be running on RedHat, Centos, Fedora, Rocky Linux or Oracle Linux, so quitting"
             echo " "
             exit 1
         fi


### PR DESCRIPTION
Install on [Rocky Linux](https://rockylinux.org/) fails, although being an RHEL rebuild and a CentOS alternative.

Solution Tested on Rocky Linux:

```bash
Running nodejs and Node-RED install for user dgoo2308 at /home/dgoo2308 on "rocky"

[sudo] password for dgoo2308:
  Stop Node-RED                       ✔
  Install Node.js LTS                 ✔   Node v14.17.5   Npm 6.14.14
  Install Node-RED core               ✔   2.0.5
  Add shortcut commands               ✔
  Update systemd script               ✔
  Update public zone firewall rule    ✔


Any errors will be logged to   /var/log/nodered-install.log
All done.
  You can now start Node-RED with the command  node-red-start
  Then point your browser to localhost:1880 or http://{your_ip-address}:1880

Started  Sun Aug 22 01:25:12 EDT 2021  -  Finished  Sun Aug 22 01:27:10 EDT 2021

```