### PR TITLE
Do not update systemd script if file exists

### DIFF
--- a/deb/update-nodejs-and-nodered
+++ b/deb/update-nodejs-and-nodered
@@ -569,17 +569,54 @@ case $yn in
             fi
 
             # add systemd script and configure it for $NODERED_USER
-            echo "Now add systemd script and configure it for $NODERED_USER" | sudo tee -a /var/log/nodered-install.log >>/dev/null
-            if sudo curl -sL -o /lib/systemd/system/nodered.service https://raw.githubusercontent.com/node-red/linux-installers/master/resources/nodered.service 2>&1 | sudo tee -a /var/log/nodered-install.log >>/dev/null; then CHAR=$TICK; else CHAR=$CROSS; fi
+            echo "Now add systemd script and configure it for $NODERED_USER:$NODERED_GROUP @ $NODERED_HOME" | sudo tee -a /var/log/nodered-install.log >>/dev/null
+
+            # check if systemd script already exists
+            SYSTEMDFILE="/lib/systemd/system/nodered.service"
+            SYSTEMDMESSAGE=""
+
+            if test -f "$SYSTEMDFILE"; then
+                
+                EXISTING_USER=$(sed -nr "/^\[Service\]/ { :l /^User[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" $SYSTEMDFILE);
+                EXISTING_GROUP=$(sed -nr "/^\[Service\]/ { :l /^Group[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" $SYSTEMDFILE);
+                EXISTING_HOME=$(sed -nr "/^\[Service\]/ { :l /^WorkingDirectory[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" $SYSTEMDFILE);
+
+                echo "systemd script found for $EXISTING_USER:$EXISTING_GROUP @ $EXISTING_HOME.";
+
+                if [[ $EXISTING_USER == $NODERED_USER && $EXISTING_GROUP == $NODERED_GROUP && $EXISTING_HOME == $NODERED_HOME ]];
+                then
+                    SYSTEMDFILE+=".alt"
+                    echo "Existing systemd script matches current installation. To prevent loss of modifications, we'll not recreate the systemd script."
+                    echo "An alternative (standard) script will be created as $SYSTEMDFILE."
+
+                    SYSTEMDMESSAGE=" File existed. Not modified."
+                else
+
+                    BACKUPFILE=${SYSTEMDFILE}.backup
+                    BACKUPFILECOUNTER=0
+
+                    while test -f "$BACKUPFILE";
+                    do
+                        ((BACKUPFILECOUNTER+=1))
+                        BACKUPFILE=${SYSTEMDFILE}.backup.${BACKUPFILECOUNTER}
+                    done
+
+                    echo "Existing systemd script does not match the current installation! We'll backup this file and create a new standard script."
+                    sudo mv $SYSTEMDFILE ${BACKUPFILE}
+                    SYSTEMDMESSAGE=" Existing script moved to ${BACKUPFILE}"
+                fi
+            fi
+
+            if sudo curl -sL -o $SYSTEMDFILE https://raw.githubusercontent.com/node-red/linux-installers/master/resources/nodered.service 2>&1 | sudo tee -a /var/log/nodered-install.log >>/dev/null; then CHAR=$TICK; else CHAR=$CROSS; fi
             # set the memory, User Group and WorkingDirectory in nodered.service
             if [ $(cat /proc/meminfo | grep MemTotal | cut -d ":" -f 2 | cut -d "k" -f 1 | xargs) -lt 894000 ]; then mem="256"; else mem="512"; fi
             if [ $(cat /proc/meminfo | grep MemTotal | cut -d ":" -f 2 | cut -d "k" -f 1 | xargs) -gt 1894000 ]; then mem="1024"; fi
             if [ $(cat /proc/meminfo | grep MemTotal | cut -d ":" -f 2 | cut -d "k" -f 1 | xargs) -gt 3894000 ]; then mem="2048"; fi
             # if [ $(cat /proc/meminfo | grep MemTotal | cut -d ":" -f 2 | cut -d "k" -f 1 | xargs) -gt 7894000 ]; then mem="4096"; fi
-            sudo sed -i 's#=512#='$mem'#;' /lib/systemd/system/nodered.service
-            sudo sed -i 's#^User=pi#User='$NODERED_USER'#;s#^Group=pi#Group='$NODERED_GROUP'#;s#^WorkingDirectory=/home/pi#WorkingDirectory='$NODERED_HOME'#;s#^EnvironmentFile=-/home/pi#EnvironmentFile=-'$NODERED_HOME'#;' /lib/systemd/system/nodered.service
+            sudo sed -i 's#=512#='$mem'#;' $SYSTEMDFILE
+            sudo sed -i 's#^User=pi#User='$NODERED_USER'#;s#^Group=pi#Group='$NODERED_GROUP'#;s#^WorkingDirectory=/home/pi#WorkingDirectory='$NODERED_HOME'#;s#^EnvironmentFile=-/home/pi#EnvironmentFile=-'$NODERED_HOME'#;' $SYSTEMDFILE
             sudo systemctl daemon-reload 2>&1 | sudo tee -a /var/log/nodered-install.log >>/dev/null
-            echo -ne "  Update systemd script               $CHAR\r\n"
+            echo -ne "  Update systemd script               $CHAR$SYSTEMDMESSAGE\r\n"
         else
             echo -ne "  Add shortcut commands               :   Skipped - systemd not found\r\n"
             echo -ne "  Update systemd script               :   Skipped - systemd not found\r\n"


### PR DESCRIPTION
Currently `nodered.service` is **always** recreated from the GitHub master template as part of the update process (at least on RPi). Any modification (e.g. definition of a custom `--userDir`) in this file thus will be overwritten - without notice or warning.

This PR adds the following logic:

- If the file does not exist, create it - as usual.
- If the file exists and the definition of `User:Group` and `WorkingDirectory` matches the current installation: Keep the existing file & additionally create an alternative one from the master template. This allows to compare the both files in case of doubt.
- If the file exists and the definition of `User:Group` and `WorkingDirectory` **does not match** the current installation: Backup the existing file & create a new one from the master template. This ensures that the modifications (at least) are preserved...

Closes #25.