### PR TITLE
Add support for MIRACLE LINUX

### DIFF
--- a/rpm/update-nodejs-and-nodered
+++ b/rpm/update-nodejs-and-nodered
@@ -64,10 +64,10 @@ case $yn in
         }
 
         MYOS=$(cat /etc/*release | grep "^ID=" | cut -d = -f 2)
-        versions='fedora"centos"rhel"ol"almalinux"rocky"'
+        versions='fedora"centos"rhel"ol"almalinux"rocky"miraclelinux"'
         if [[ $versions != *"$MYOS"* ]]; then
             echo " "
-            echo "Doesn't seem to be running on RedHat, Centos, Fedora, Rocky, Alma, or Oracle Linux, so quitting"
+            echo "Doesn't seem to be running on RedHat, Centos, Fedora, Rocky, Alma, Oracle Linux, or MIRACLE LINUX so quitting"
             echo " "
             exit 1
         fi
@@ -100,7 +100,7 @@ case $yn in
         # ensure ~/.config dir is owned by the user
         sudo chown -Rf $NODERED_USER:$NODERED_GROUP $NODERED_HOME/.config/
         echo "Now install nodejs" | sudo tee -a /var/log/nodered-install.log >>/dev/null
-        if [ $MYOS = "fedora" ] || [ $MYOS = "almalinux" ] || [ $MYOS = "rocky" ]; then
+        if [ $MYOS = "fedora" ] || [ $MYOS = "almalinux" ] || [ $MYOS = "rocky" ] || [ $MYOS = "miraclelinux" ]; then
             sudo dnf module reset -y nodejs 2>&1 | sudo tee -a /var/log/nodered-install.log >>/dev/null
             if sudo dnf module install -y nodejs:14/default 2>&1 | sudo tee -a /var/log/nodered-install.log >>/dev/null; then CHAR=$TICK; else CHAR=$CROSS; fi
         else


### PR DESCRIPTION
The installer for RPM-based systems refuses to run on MIRACLE LINUX,
which is a RHEL-derivative and compatible with node-red.

This commit adds MIRACLE LINUX to the list of recognized distributions
of the installer for RPM-based systems.

I have confirmed that this works on MIRACLE LINUX 8.4.

```
Running nodejs and Node-RED install for user asdf at /home/asdf on "miraclelinux"

  Stop Node-RED                       ✔
  Install Node.js LTS                 ✔   Node v14.19.0   Npm 6.14.16
  Install Node-RED core               ✔   2.2.0
  Add shortcut commands               ✔
  Update systemd script               ✔
  Update public zone firewall rule    ✔

Any errors will be logged to   /var/log/nodered-install.log
All done.
  You can now start Node-RED with the command  node-red-start
  Then point your browser to localhost:1880 or http://{your_ip-address}:1880

Started  2022年  2月  2日 水曜日 16:22:47 JST  -  Finished  2022年  2月  2日 水曜日 16:23:21 JST
```