### PR TITLE
Fix return code error when no-init specified

### DIFF
--- a/deb/update-nodejs-and-nodered
+++ b/deb/update-nodejs-and-nodered
@@ -758,6 +758,10 @@ case $yn in
                 node-red admin init
                 $SUDO chown 0:0 ~/.node-red/settings.js
                 ;;
+                "n")
+                echo "With the option no-init specified, the settings is not initialized."
+                exit 0
+                ;;
                 * )
                 echo " "
                 exit 1


### PR DESCRIPTION
When the option no-init is specified, the variable INITSET and initset will be set as "n", which is not well handeled by "case $initset", and results "exit 1".

To address this, a case "n" is added and make it be ended with "exit 0"

Signed-off-by: Zhi Han <z.han@kunbus.com>