### PR TITLE
Fix the path to the node-red executable for the admin init

### DIFF
--- a/deb/update-nodejs-and-nodered
+++ b/deb/update-nodejs-and-nodered
@@ -831,7 +831,7 @@ case $yn in
                 [Yy]* )
                 export HOSTIP=`hostname -I | cut -d ' ' -f 1`
                 $SUDO chown -Rf $NODERED_USER:$NODERED_GROUP $NODERED_HOME/.node-red 2>&1 >>/dev/null
-                $SUDOU /usr/bin/node-red admin init
+                $SUDOU /usr/local/bin/node-red admin init
                 $SUDO chown 0:0 $file
                 ;;
                 [Nn]* )
@@ -842,7 +842,7 @@ case $yn in
                 # echo " "
                 # exit 1
                 $SUDO chown -Rf $NODERED_USER:$NODERED_GROUP $NODERED_HOME/.node-red/ 2>&1 >>/dev/null
-                $SUDOU /usr/bin/node-red admin init
+                $SUDOU /usr/local/bin/node-red admin init
                 $SUDO chown 0:0 $file
                 ;;
             esac


### PR DESCRIPTION
The path to node-red is not /usr/bin/ but /usr/local/bin/, fix this path to correct an error at the end