### PR TITLE
Enable script download tracking for Node-RED Installer Scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Create Release with Scripts
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version for the release (e.g., v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set version
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" == "push" ]; then
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        else
+          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Create release directory
+      run: mkdir -p release-assets
+    
+    - name: Copy installer scripts
+      run: |
+        cp deb/update-nodejs-and-nodered release-assets/update-nodejs-and-nodered-deb
+        cp rpm/update-nodejs-and-nodered release-assets/update-nodejs-and-nodered-rpm
+        chmod +x release-assets/update-nodejs-and-nodered-*
+    
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version.outputs.VERSION }}
+        name: Node-RED Linux Installers ${{ steps.version.outputs.VERSION }}
+        body: |
+          Node-RED Linux installer scripts for various distributions.
+          
+          ## Installation
+          
+          ### Debian, Ubuntu, Raspberry Pi OS
+          ```bash
+          bash <(curl -sL https://github.com/node-red/linux-installers/releases/download/${{ steps.version.outputs.VERSION }}/update-nodejs-and-nodered-deb)
+          ```
+          
+          ### Red Hat, Fedora, CentOS, Oracle Linux
+          ```bash
+          bash <(curl -sL https://github.com/node-red/linux-installers/releases/download/${{ steps.version.outputs.VERSION }}/update-nodejs-and-nodered-rpm)
+          ```
+          
+          ## Changes
+          - Updated installer scripts
+          - See commit history for detailed changes
+        files: |
+          release-assets/update-nodejs-and-nodered-deb
+          release-assets/update-nodejs-and-nodered-rpm
+        draft: false
+        prerelease: false


### PR DESCRIPTION
## Problem
GitHub does not provide download statistics for raw files accessed via `raw.githubusercontent.com`. This makes it impossible to track usage analytics for the Node-RED installer scripts currently distributed through raw GitHub URLs.

## Solution
This PR migrates the distribution method from raw GitHub URLs to GitHub release assets, which do provide download statistics via the GitHub API.

## Changes Made

1. **GitHub Actions Workflow** (`.github/workflows/release.yml`)
   - Automatically creates releases when tags are pushed or manually triggered
   - Packages installer scripts as release assets with clear naming:
     - `update-nodejs-and-nodered-deb` (Debian/Ubuntu)
     - `update-nodejs-and-nodered-rpm` (RPM-based systems)
   - Generates release notes with updated installation instructions

2. **README Updates**
   - Updated all installation commands to use GitHub release URLs
   - Changed from `https://raw.githubusercontent.com/node-red/linux-installers/master/...` 
   - To `https://github.com/node-red/linux-installers/releases/latest/download/...`

## Benefits
- **Download Analytics**: GitHub release assets provide download statistics via the API
- **Versioning**: Each release is tagged and versioned for better tracking
- **Consistency**: All installer downloads go through the same tracked mechanism
- **Backward Compatibility**: Installation process remains identical for end users

## Usage
To create a new release with updated scripts:
```bash
git tag v1.0.0
git push origin v1.0.0
```

Or trigger manually from GitHub Actions tab.

## Note

- Downstream Distro installer scripts might need to be updated to make use of these new urls
- GitHub's API provides the raw data (cumulative download counts) but no built-in historical tracking. We'd need to implement our own monitoring system to track downloads over time.